### PR TITLE
fix: 修复线(Edge)段动画失效问题

### DIFF
--- a/src/canvas/baseCanvas.js
+++ b/src/canvas/baseCanvas.js
@@ -605,6 +605,10 @@ class BaseCanvas extends Canvas {
 
         _edgeFragment.appendChild(edge.dom);
 
+        if (edge.animateDom) {
+          $(edge.animateDom).insertAfter(edge.dom)
+        }
+
         if (edge.labelDom) {
           _labelFragment.appendChild(edge.labelDom);
         }

--- a/src/utils/link_animate.js
+++ b/src/utils/link_animate.js
@@ -52,7 +52,6 @@ let addAnimate = (targetDom, path, options = {}, animateDom) => {
 
   if (!_animateDom) {
     _animateDom = circle;
-    $(_animateDom).insertAfter(targetDom);
   }
 
   return _animateDom;


### PR DESCRIPTION
在Edge的addAnimate 方法中，尝试对没有父级的Edge.dom后insertAfter一个animateDom，但这句话是失效的，需要将Edge.dom挂载到_edgeFragment之后才可insertAfter成功