### PR TITLE
fix: `type` and `Class` are overridden in object spread

### DIFF
--- a/react/util/process.js
+++ b/react/util/process.js
@@ -6,8 +6,8 @@ const process = ({nodes = [], edges = [], groups = []}) => {
   return {
     nodes: nodes.map((node) => {
       return {
-        ...node,
         Class: Node,
+        ...node,
       };
     }),
     edges: edges.map(edge => {
@@ -15,15 +15,15 @@ const process = ({nodes = [], edges = [], groups = []}) => {
       labelDOM.id = edge.id;
 
       return {
-        ...edge,
         type: 'endpoint',
         Class: Edge,
+        ...edge,
       };
     }),
     groups: groups.map(group => {
       return {
-        ...group,
         Class: Group,
+        ...group,
       };
     })
   };

--- a/vue/util/process.js
+++ b/vue/util/process.js
@@ -8,8 +8,8 @@ const process = ({nodes = [], edges = [], groups = []}) => {
   return {
     nodes: nodes.map((node) => {
       return {
-        ...node,
         Class: Node,
+        ...node,
       };
     }),
     edges: edges.map(edge => {
@@ -17,15 +17,15 @@ const process = ({nodes = [], edges = [], groups = []}) => {
       labelDOM.id = edge.id;
 
       return {
-        ...edge,
         type: 'endpoint',
         Class: Edge,
+        ...edge,
       };
     }),
     groups: groups.map(group => {
       return {
-        ...group,
         Class: Group,
+        ...group,
       };
     })
   };


### PR DESCRIPTION
When trying to use the components from the `butterfly-vue` and `butterfly-react`, the supplied `type` and `Class` properties are being overridden and don't work as intended.

For example:
```js
export default {
  nodes: [
    {
      id: '1',
      label: '张三',
      left: 600,
      top: 50,
      iconType: 'icon-wo',
      Class: CustomNode,
      endpoints: [
        {
          id: 'right',
          orientation: [1, 0],
          pos: [0, 0.5],
        },
        {
          id: 'bottom',
          orientation: [0, 1],
          pos: [0.5, 0],
        },
        {
          id: 'left',
          orientation: [-1, 0],
          pos: [0, 0.5],
        },
      ],
    },
    ...
  ],
  ...
}
```

The node won't be the `CustomNode`, but the default `Node`.
