### PR TITLE
feat: 为hover在endpoint产生的tips添加了一个参数：needTipsHidden. by sdjalft

### DIFF
--- a/src/utils/toolTip.js
+++ b/src/utils/toolTip.js
@@ -185,7 +185,9 @@ let createTip = (opts, callback) => {
     currentTips.addEventListener('mouseout', _mouseOut);
   });
 
+  const _targetMouseOut = targetDom.onmouseout;
   targetDom.onmouseout = (e) => {
+    _targetMouseOut(e);
     if (notEventThrough) {
       e.stopPropagation();
       e.preventDefault();
@@ -194,7 +196,9 @@ let createTip = (opts, callback) => {
     _hide();
   };
 
-  targetDom.onmousedown = () => {
+  const _targetMouseDown = targetDom.onmousedown;
+  targetDom.onmousedown = (e) => {
+    _targetMouseDown(e);
     if (needTipsHidden) {
       const _setClickFalse = () => {
         isMouseClick = false;
@@ -206,10 +210,6 @@ let createTip = (opts, callback) => {
       _hide();
     }
   };
-
-  document.addEventListener('mouseup', () => {
-    isMouseClick = false;
-  });
 };
 
 let currentMenu = null;

--- a/src/utils/toolTip.js
+++ b/src/utils/toolTip.js
@@ -185,22 +185,28 @@ let createTip = (opts, callback) => {
     currentTips.addEventListener('mouseout', _mouseOut);
   });
 
-  targetDom.addEventListener('mouseout', (e) => {
+  targetDom.onmouseout = (e) => {
     if (notEventThrough) {
       e.stopPropagation();
       e.preventDefault();
     }
     isMouseInTarget = false;
     _hide();
-  });
+  };
 
-  targetDom.addEventListener('mousedown', () => {
+  targetDom.onmousedown = () => {
     if (needTipsHidden) {
+      const _setClickFalse = () => {
+        isMouseClick = false;
+        document.removeEventListener('mouseup', _setClickFalse);
+      };
+      document.addEventListener('mouseup', _setClickFalse);
       isMouseClick = true;
       isMouseInTarget = false;
       _hide();
     }
-  });
+  };
+
   document.addEventListener('mouseup', () => {
     isMouseClick = false;
   });

--- a/src/utils/toolTip.js
+++ b/src/utils/toolTip.js
@@ -132,12 +132,20 @@ let createTip = (opts, callback) => {
   let tipstDom = null;
   let isMouseInTips = false;
   let isMouseInTarget = false;
+  let isMouseClick = false;
   let timer = null;
   let notEventThrough = !!opts.notEventThrough;
+  // 传入参数：是否需要在用户点击endpoint之后隐藏tips
+  const needTipsHidden = opts.needTipsHidden === undefined? true : opts.needTipsHidden? true : false;
   let _mouseIn = (e) => {
-    isMouseInTips = true;
+    if (!isMouseClick) {
+      isMouseInTips = true;
+    } else {
+      isMouseInTips = false;
+    }
   }
   let _mouseOut = (e) => {
+    isMouseClick = false;
     isMouseInTips = false;
     _hide();
   }
@@ -153,10 +161,13 @@ let createTip = (opts, callback) => {
         currentTips.removeEventListener('mouseout', _mouseOut);
       }
     }, 50);
-  }
+  };
   let {data, targetDom, genTipDom} = opts;
   let _tipsDom = opts.tipsDom;
   targetDom.addEventListener('mouseover', (e) => {
+    if (isMouseClick) {
+      return;
+    }
     if (notEventThrough) {
       e.stopPropagation();
       e.preventDefault();
@@ -183,6 +194,16 @@ let createTip = (opts, callback) => {
     _hide();
   });
 
+  targetDom.addEventListener('mousedown', () => {
+    if (needTipsHidden) {
+      isMouseClick = true;
+      isMouseInTarget = false;
+      _hide();
+    }
+  });
+  document.addEventListener('mouseup', () => {
+    isMouseClick = false;
+  });
 };
 
 let currentMenu = null;


### PR DESCRIPTION
在createTips中添加参数:needTipsHidden: true可以让用户在拖动endpoint的时候tips不会遮挡，默认为true。

将属性设置为false可以避免该事发生。

注：我没有找到销毁监听器的时机，所以并没有写销毁事件（原来版本一些监听器就没销毁）