### PR TITLE
fix(vue): use global instance for renderer component

### DIFF
--- a/vue/util/add-com.js
+++ b/vue/util/add-com.js
@@ -70,6 +70,7 @@ const render = (item, type, parent = null, canvasNodes = null) => {
     propsData.canvasNode = canvasNode;
   
     const nodeCon = new vueCon({
+      parent: parent,
       propsData
     });
     nodeCon.$butterfly = {


### PR DESCRIPTION
close #774

Not really sure for that one, but it seems it works for vuex & vue-l18n in my case