### PR TITLE
feat: 新增 BaseNode 类中 的 mousedown 和 click 事件预处理

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "butterfly-dag",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "description": "一个基于数据驱动的节点式编排组件库，让你有方便快捷定制可视化流程图表",
   "main": "dist/index.js",
   "es": "es/index.js",

--- a/src/node/baseNode.js
+++ b/src/node/baseNode.js
@@ -200,6 +200,9 @@ class BaseNode extends Node {
       if (e.button !== LEFT_KEY) {
         return;
       }
+      if(_.isFunction(this.canMouseDown) && !this.canMouseDown(e)) {
+        return;
+      }
       if (!['SELECT', 'INPUT', 'RADIO', 'CHECKBOX', 'TEXTAREA'].includes(e.target.nodeName)) {
         e.preventDefault();
       }
@@ -219,6 +222,9 @@ class BaseNode extends Node {
     });
 
     $(this.dom).on('click', (e) => {
+      if(_.isFunction(this.canClick) && !this.canClick(e)) {
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
       this.emit('system.node.click', {


### PR DESCRIPTION
## feat: 新增 BaseNode 类中 mousedown 和 click 事件预处理
### 改动原因：
原来的 baseNode 类中对于 mousedown 和 click 事件无法进行很好的判断，例如在 node 中放置下拉框的情况下，无法点击 node 中的下拉框，而会在 mousedown 事件中进行 drag 操作。 
### 改动点：
* mousedown 事件处理：在执行后续 darg 判断前，先判断是否有 canMouseDown 函数，根据执行结果判断是否要继续进行 darg 判断。
* click 事件处理： 在执行后续 click 操作前，先判断是否有 canClick 函数，根据执行结果判断是否要继续进行后续的 click 事件处理。