### PR TITLE
attach listeners to `vue-endpoint` component

### DIFF
--- a/vue/coms/vue-endpoint.vue
+++ b/vue/coms/vue-endpoint.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :id="'bf_endpoint_'+id" :class="className">
+  <div v-on="$listeners" :id="'bf_endpoint_'+id" :class="className">
     <slot>
       <div>
         {{id}}


### PR DESCRIPTION
This change helps us listen to endpoint clicks on the `ButterflyVueEndpoint` component.