### PR TITLE
fix: 修复带圆角的 Manhattan 类型线条在存在距离较短的相邻点时圆角过大导致线条出现s型转折

### DIFF
--- a/src/utils/link/edgeTypes/manhattan.js
+++ b/src/utils/link/edgeTypes/manhattan.js
@@ -62,10 +62,15 @@ const getDrawPoint = (start, control, end, radius) => {
 function getRadiusPath(pointArr) {
   let path = ""
   let radius = DEFAULT_RADIUS;
-  const [start, c1, c2] = pointArr;
-  const end = pointArr[pointArr.length - 1]
-  if (Math.abs(start.y - end.y) < 2 * DEFAULT_RADIUS) {
-    radius = Math.abs(start.y - end.y) / 2;
+  const end = pointArr[pointArr.length - 1];
+  
+  for (let i = 1; i < pointArr.length; i++) {
+    const curr = pointArr[i];
+    const prev = pointArr[i - 1];
+
+    const length = Math.max(Math.abs(prev.x - curr.x), Math.abs(prev.y - curr.y));
+
+    radius = Math.min(radius, length / 2);
   }
 
   if (


### PR DESCRIPTION
问题如下：
![image](https://user-images.githubusercontent.com/6480386/180979866-54a516b2-d4f1-442b-9946-692e668efcce.png)
