### PR TITLE
fix: 修复dagreLayout布局异常的bug

### DIFF
--- a/src/utils/layout/dagreLayout.js
+++ b/src/utils/layout/dagreLayout.js
@@ -48,7 +48,7 @@ function dagreLayout(param) {
     });
     edges.forEach(edge => {
       // dagrejs Wiki https://github.com/dagrejs/dagre/wiki#configuring-the-layout
-      g.setEdge(edge.source, edge.target, {
+      g.setEdge(edge.source.id, edge.target.id, {
         weight: edge.weight || 1
       });
     });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22325851/195299616-c71cf635-7a72-4e73-90d9-07712c48467a.png)
setEdge应该传入源宿的id，不是对象，没有传入连线，效果不对了
https://github.com/dagrejs/dagre/wiki#an-example-layout